### PR TITLE
Update CI environment using JDK17, update plugin elasticsearch version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        jdk: [ '11', '17' ]
+        jdk: [ '17' ]
     name: CI using JDK ${{ matrix.jdk }}
     steps:
       - uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id "com.diffplug.spotless" version "6.8.0"
 }
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 apply plugin: 'distribution'
 

--- a/src/main/dist/plugin-descriptor.properties
+++ b/src/main/dist/plugin-descriptor.properties
@@ -32,10 +32,10 @@ classname=com.github.yokotaso.elasticsearch.plugin.analysis.classic.ckj.ClassicC
 # use the system property java.specification.version
 # version string must be a sequence of nonnegative decimal integers
 # separated by "."'s and may have leading zeros
-java.version=11
+java.version=17
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=7.15.2
+elasticsearch.version=7.17.5
 ### optional elements for plugins:
 #
 #  'extended.plugins': other plugins this plugin extends through SPI


### PR DESCRIPTION
- Remove CI using JDK11
- Update elasticsearch version in plugin descriptor
- Use JDK17 