### PR TITLE
FTSOP-382: Add minimumReleaseAge (14 days) to Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "packagePatterns": ["^org.assertj", "^org.junit", "^junit", "^com.diffplug.spotless"],


### PR DESCRIPTION
https://bozuman.cybozu.com/k/82096/show#record=382

## 概要

サービス運用ポリシー・ルール集に追記された [Renovate/Dependabot 利用時のルール](https://github.dev.cybozu.co.jp/pages/kaiun/operational-rules/ci_cd/#mimimumrelaseagecooldown) に対応し、Renovate の `minimumReleaseAge` を設定します。

## 変更内容

- `renovate.json5` に `"minimumReleaseAge": "14 days"` を追加

## 背景

Renovate/Dependabot により依存ライブラリ更新PRが自動作成されると、悪意あるコードが混入していた場合でもCIが実行され得る点が [TTP-11](https://bozuman.cybozu.com/k/86614/show#record=11) で課題として挙げられていました。
このリスクの緩和策として、リリースから一定期間経過後にPRを作成する `minimumReleaseAge` を設定します。

## 補足

- Renovate の `vulnerabilityAlerts` は `minimumReleaseAge` をバイパスするため、セキュリティ修正の迅速な適用は妨げません。